### PR TITLE
Use `t` type from Yojson

### DIFF
--- a/lib/stitch.ml
+++ b/lib/stitch.ml
@@ -26,8 +26,8 @@ end
 
 module Recorded_call = struct
   type t =
-    { arguments : Yojson.Safe.json list
-    ; return_value : Yojson.Safe.json
+    { arguments : Yojson.Safe.t list
+    ; return_value : Yojson.Safe.t
     ; execution_time : float
     }
   [@@deriving yojson]
@@ -36,8 +36,8 @@ end
 module Function = struct
   module Argument = struct
     type 'a t =
-      { to_yojson : 'a -> Yojson.Safe.json
-      ; of_yojson : Yojson.Safe.json -> ('a, string) result
+      { to_yojson : 'a -> Yojson.Safe.t
+      ; of_yojson : Yojson.Safe.t -> ('a, string) result
       }
     [@@deriving make]
 
@@ -47,8 +47,8 @@ module Function = struct
 
   module Return_value = struct
     type 'a t =
-      { to_yojson : 'a -> Yojson.Safe.json
-      ; of_yojson : Yojson.Safe.json -> ('a, string) result
+      { to_yojson : 'a -> Yojson.Safe.t
+      ; of_yojson : Yojson.Safe.t -> ('a, string) result
       ; equal : 'a -> 'a -> bool
       ; show : 'a -> string
       }

--- a/lib/stitch.mli
+++ b/lib/stitch.mli
@@ -23,8 +23,8 @@ module Function : sig
     type 'a t
 
     val make :
-      to_yojson: ('a -> Yojson.Safe.json) ->
-      of_yojson: (Yojson.Safe.json -> ('a, string) result) ->
+      to_yojson: ('a -> Yojson.Safe.t) ->
+      of_yojson: (Yojson.Safe.t -> ('a, string) result) ->
       'a t
   end
 
@@ -32,8 +32,8 @@ module Function : sig
     type 'a t
 
     val make :
-      to_yojson: ('a -> Yojson.Safe.json) ->
-      of_yojson: (Yojson.Safe.json -> ('a, string) result) ->
+      to_yojson: ('a -> Yojson.Safe.t) ->
+      of_yojson: (Yojson.Safe.t -> ('a, string) result) ->
       equal: ('a -> 'a -> bool) ->
       show: ('a -> string) ->
       'a t

--- a/stitch.opam
+++ b/stitch.opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {>= "2.0.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 tags: ["org:cryptosense"]
 synopsis: "Refactoring framework"


### PR DESCRIPTION
Yojson 2.0 is going to remove the already deprecated type, so this PR switches to the new type name.